### PR TITLE
Feat: 개인정보처리방침 링크 및 권한 확인 기능 추가, 회원탈퇴 스크린 헤더 추가 #42

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,12 +1,50 @@
 # Resolve react_native_pods.rb with node to allow for hoisting
-require Pod::Executable.execute_command('node', ['-p',
-  'require.resolve(
-    "react-native/scripts/react_native_pods.rb",
-    {paths: [process.argv[1]]},
-  )', __dir__]).strip
+# require Pod::Executable.execute_command('node', ['-p',
+#   'require.resolve(
+#     "react-native/scripts/react_native_pods.rb",
+#     {paths: [process.argv[1]]},
+#   )', __dir__]).strip
+
+# permissions 사용을 위한 코드 수정
+def node_require(script)
+  # Resolve script with node to allow for hoisting
+  require Pod::Executable.execute_command('node', ['-p',
+    "require.resolve(
+      '#{script}',
+      {paths: [process.argv[1]]},
+    )", __dir__]).strip
+end
+
+node_require('react-native/scripts/react_native_pods.rb')
+node_require('react-native-permissions/scripts/setup.rb')
 
 platform :ios, min_ios_version_supported
 prepare_react_native_project!
+
+
+# ⬇️ uncomment the permissions you need
+setup_permissions([
+  # 'AppTrackingTransparency',
+  # 'Bluetooth',
+  # 'Calendars',
+  # 'CalendarsWriteOnly',
+  # 'Camera',
+  # 'Contacts',
+  # 'FaceID',
+  'LocationAccuracy',
+  'LocationAlways',
+  'LocationWhenInUse',
+  # 'MediaLibrary',
+  # 'Microphone',
+  # 'Motion',
+  # 'Notifications',
+  # 'PhotoLibrary',
+  # 'PhotoLibraryAddOnly',
+  # 'Reminders',
+  # 'Siri',
+  # 'SpeechRecognition',
+  # 'StoreKit',
+])
 
 linkage = ENV['USE_FRAMEWORKS']
 if linkage != nil

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1707,6 +1707,27 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
+  - RNPermissions (5.2.3):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - RNReanimated (3.16.3):
     - DoubleConversion
     - glog
@@ -1964,6 +1985,7 @@ DEPENDENCIES:
   - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - "RNGoogleSignin (from `../node_modules/@react-native-google-signin/google-signin`)"
   - "RNNaverLogin (from `../node_modules/@react-native-seoul/naver-login`)"
+  - RNPermissions (from `../node_modules/react-native-permissions`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
@@ -2135,6 +2157,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/@react-native-google-signin/google-signin"
   RNNaverLogin:
     :path: "../node_modules/@react-native-seoul/naver-login"
+  RNPermissions:
+    :path: "../node_modules/react-native-permissions"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
@@ -2229,12 +2253,13 @@ SPEC CHECKSUMS:
   RNGestureHandler: 0e5ae8d72ef4afb855e98dcdbe60f27d938abe13
   RNGoogleSignin: edec18754ff4af2cfee46072609ec5a7a754291a
   RNNaverLogin: 29e5376e5ec173b77a8c1c68cac2649b092fd8bb
+  RNPermissions: f10d86e93f46508c1ddc0c4c56002d7686a66da2
   RNReanimated: 006a5d3961bf09c1e96d62ed436e02b2e43b89bb
   RNScreens: 44a3e358d5ccd7815c5ae9148988c562826992b2
   RNSVG: ec2e9d524612ee95db5df143a54518c5404d93f0
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: db69236006b8b1c6d55ab453390c882306cbf219
 
-PODFILE CHECKSUM: 43552dc15f0cc08d869d47da7d828475c4cc7632
+PODFILE CHECKSUM: a2dcce644d7762287f547403901d3256f6f49942
 
 COCOAPODS: 1.16.2

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-native-get-random-values": "^1.11.0",
     "react-native-google-places-autocomplete": "^2.5.7",
     "react-native-maps": "^1.20.1",
+    "react-native-permissions": "^5.2.3",
     "react-native-reanimated": "^3.16.1",
     "react-native-safe-area-context": "^4.14.0",
     "react-native-screens": "^4.0.0",

--- a/src/components/modal/PermissionBackGround.tsx
+++ b/src/components/modal/PermissionBackGround.tsx
@@ -1,0 +1,30 @@
+import { SafeAreaView, StyleSheet } from 'react-native'
+import AppText from '../common/AppText'
+
+type PermissionModalPropsType = {
+  description: string
+}
+
+function PermissionBackground({ description }: PermissionModalPropsType) {
+  return (
+    <SafeAreaView style={styles.container}>
+      <AppText style={styles.description}>{description}</AppText>
+    </SafeAreaView>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    width: '100%',
+    backgroundColor: 'black',
+  },
+  description: {
+    color: 'white',
+    flex: 1,
+    marginTop: 60,
+    fontSize: 20,
+    textAlign: 'center',
+  },
+})
+export default PermissionBackground

--- a/src/constants/permissions.ts
+++ b/src/constants/permissions.ts
@@ -1,0 +1,21 @@
+import { PERMISSIONS } from 'react-native-permissions'
+
+export const androidPermissions = {
+  location: PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
+  coarseLocation: PERMISSIONS.ANDROID.ACCESS_COARSE_LOCATION,
+  // photo: PERMISSIONS.ANDROID.READ_EXTERNAL_STORAGE,
+}
+export const iosPermissions = {
+  location: PERMISSIONS.IOS.LOCATION_WHEN_IN_USE, //always?
+  // photo: PERMISSIONS.IOS.PHOTO_LIBRARY,
+}
+export const permissionRequestMessage = {
+  location: '현재 위치 표시를 위해\n위치 권한을 허용해주세요.',
+  // photo: '사진 업로드를 위해\n앨범 접근 권한을 허용해주세요.',
+}
+export const failedMessages = {
+  PERMISSION_UNAVAILABLE: 'This feature is not available (on this device / in this context)',
+  PERMISSION_BLOCKED: 'The permission is denied and not requestable',
+  PERMISSION_DENIED: 'The permission has not been requested / is denied but requestable',
+  PERMISSION_LIMITED: 'The permission has not been requested / is denied but requestable',
+}

--- a/src/constants/variables.ts
+++ b/src/constants/variables.ts
@@ -4,3 +4,6 @@ export const COLORS = {
   dinosRed: '#FF2121',
   deactivated: '#B1B3B5',
 }
+
+export const privacyUrl = 'https://dinos-dev.github.io/privacy-dinos/'
+export const serviceUrl = 'https://dinos-dev.github.io/privacy-dinos/'

--- a/src/hooks/usePermission.ts
+++ b/src/hooks/usePermission.ts
@@ -1,0 +1,74 @@
+import { useState } from 'react'
+import { Alert, Platform } from 'react-native'
+import { check, RESULTS, request, PermissionStatus, openSettings } from 'react-native-permissions'
+import { androidPermissions, failedMessages, iosPermissions, permissionRequestMessage } from '../constants/permissions'
+
+type PossiblePermission = 'location' // | 'photo'
+interface IGetPermission {
+  permissionType: PossiblePermission
+  onSuccess?: () => void
+  onFailed?: () => void
+  isEssential?: false // 임시 , boolean
+}
+
+export const usePermission = () => {
+  const [permissionOpen, setPermissionOpen] = useState<boolean>(false)
+  const [permissionDescription, setPermissionDescription] = useState<string>('')
+
+  const permissionsPerOS = Platform.OS === 'ios' ? iosPermissions : androidPermissions
+
+  const getPermission = async ({
+    permissionType,
+    onSuccess,
+    onFailed,
+    isEssential,
+  }: IGetPermission): Promise<boolean> => {
+    const permission = permissionsPerOS[permissionType]
+    setPermissionDescription(permissionRequestMessage[permissionType])
+    setPermissionOpen(true)
+
+    const closeBackground = () => {
+      setPermissionOpen(false)
+      setPermissionDescription('')
+    }
+
+    const handlePermissionSuccess = () => {
+      if (onSuccess) onSuccess()
+      closeBackground()
+      return true
+    }
+
+    const openDeviceSettings = (message: string) => {
+      // 'alarams', 'notifications' 설정 가능
+      openSettings('application').catch(() => Alert.alert('앱 설정 화면을 열 수 없습니다.'))
+    }
+
+    const handlePermissionError = (message?: string, isEssential = false) => {
+      if (isEssential) openDeviceSettings(message || '해당 기능 사용을 위해 접근 권한이 필요합니다.')
+      if (onFailed) onFailed()
+      closeBackground()
+      return false
+    }
+
+    const status = await check(permission)
+    console.log(status)
+    let requested: PermissionStatus
+    switch (status) {
+      case RESULTS.UNAVAILABLE:
+        return handlePermissionError(failedMessages.PERMISSION_UNAVAILABLE, isEssential)
+      case RESULTS.GRANTED:
+        return handlePermissionSuccess()
+      case RESULTS.DENIED:
+        requested = await request(permission)
+        if (requested === RESULTS.GRANTED) {
+          return handlePermissionSuccess()
+        } else return handlePermissionError(failedMessages.PERMISSION_BLOCKED, isEssential)
+      // case RESULTS.LIMITED:
+      // case RESULTS.BLOCKED:
+      default:
+        return handlePermissionError(failedMessages.PERMISSION_BLOCKED, isEssential)
+    }
+  }
+
+  return { getPermission, permissionOpen, permissionDescription, check }
+}

--- a/src/navigators/members/sharedStack/MyPageSharedStack.tsx
+++ b/src/navigators/members/sharedStack/MyPageSharedStack.tsx
@@ -10,7 +10,15 @@ export default function MyPageSharedStack() {
     <Stack.Navigator screenOptions={{ headerShown: false }}>
       <Stack.Screen name={SCREENS.MY_PAGE_SCREEN} component={MyPageScreen} />
       <Stack.Screen name={SCREENS.PROFILE_SCREEN} component={ProfileScreen} />
-      <Stack.Screen name={SCREENS.WITHDRAWAL_SCREEN} component={WithdrawalScreen} />
+      <Stack.Screen
+        name={SCREENS.WITHDRAWAL_SCREEN}
+        component={WithdrawalScreen}
+        options={{
+          headerTitle: '회원탈퇴',
+          headerShown: true,
+          headerBackVisible: true,
+        }}
+      />
     </Stack.Navigator>
   )
 }

--- a/src/screens/common/LoginScreen.tsx
+++ b/src/screens/common/LoginScreen.tsx
@@ -1,8 +1,8 @@
-import { SafeAreaView, StyleSheet, View, Platform, Image } from 'react-native'
+import { SafeAreaView, StyleSheet, View, Platform, Image, TouchableOpacity, Linking } from 'react-native'
 import useAuthStore from '../../store/authStore'
 import { useAppleAuth, useGoogleAuth, useNaverAuth } from '../../hooks/socialLogin'
 import { AuthRequest } from '../../services/auth'
-import { COLORS } from '../../constants/variables'
+import { COLORS, privacyUrl } from '../../constants/variables'
 import AppButton from '../../components/common/AppButton'
 import { WelcomeText } from '../../assets/icons/TextSvg'
 import AppText from '../../components/common/AppText'
@@ -27,6 +27,9 @@ function LoginScreen() {
       //   refreshToken: res.result.refreshToken,
       // })
     }
+  }
+  const openUrl = (url: string) => {
+    Linking.openURL(url)
   }
 
   return (
@@ -71,6 +74,19 @@ function LoginScreen() {
             카카오 로그인
           </AppButton> */}
         </View>
+        <View>
+          <AppText style={styles.termsText}>회원가입 시 다이노스 서비스 필수 동의 항목인</AppText>
+          <View style={styles.paragraph}>
+            <TouchableOpacity onPress={() => openUrl(privacyUrl)}>
+              <AppText style={styles.link}>개인정보처리방침</AppText>
+            </TouchableOpacity>
+            {/* <AppText style={[styles.termsText, { marginRight: 3 }]}>과</AppText>
+            <TouchableOpacity onPress={() => openUrl(serviceUrl)}>
+              <AppText style={styles.link}>서비스 이용약관</AppText>
+            </TouchableOpacity> */}
+            <AppText style={styles.termsText}>에 동의한 것으로 간주합니다.</AppText>
+          </View>
+        </View>
       </View>
     </SafeAreaView>
   )
@@ -100,7 +116,6 @@ const styles = StyleSheet.create({
   },
   desc: {
     color: 'white',
-    fontSize: 10,
   },
   buttons: {
     flex: 1,
@@ -125,6 +140,21 @@ const styles = StyleSheet.create({
   },
   buttonText: {
     fontSize: 16,
+    fontWeight: 600,
+  },
+  termsText: {
+    color: '#d2d0d0',
+    textAlign: 'center',
+    fontSize: 12,
+    fontWeight: 500,
+  },
+  paragraph: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
+  link: {
+    color: '#ffffff',
+    fontSize: 12,
     fontWeight: 600,
   },
 })

--- a/src/screens/common/OnboardingScreen.tsx
+++ b/src/screens/common/OnboardingScreen.tsx
@@ -42,12 +42,11 @@ const styles = StyleSheet.create({
     margin: 30,
   },
   bigText: {
-    fontSize: 32,
+    fontSize: 34,
     fontWeight: 600,
     color: COLORS.white,
   },
   smallText: {
-    fontSize: 12,
     color: COLORS.white,
   },
   button: {

--- a/src/screens/myPageScreens/MyPageScreen.tsx
+++ b/src/screens/myPageScreens/MyPageScreen.tsx
@@ -53,11 +53,12 @@ const styles = StyleSheet.create({
   buttonGroup: {
     flex: 1,
     justifyContent: 'center',
-    gap: 12,
+    gap: 20,
     paddingVertical: 45,
     paddingHorizontal: 28,
   },
   button: {
+    height: 45,
     backgroundColor: COLORS.dinosRed,
     borderRadius: 12,
     justifyContent: 'center',

--- a/src/screens/myPageScreens/WithdrawalScreen.tsx
+++ b/src/screens/myPageScreens/WithdrawalScreen.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react'
-import { Alert, Text, TouchableOpacity, View, StyleSheet, SafeAreaView } from 'react-native'
+import { Alert, TouchableOpacity, View, StyleSheet, SafeAreaView } from 'react-native'
 import CheckBox from '@react-native-community/checkbox' // 커뮤니티 체크박스
 import { useNavigation } from '@react-navigation/native'
 import { NativeStackNavigationProp } from '@react-navigation/native-stack'
 import { NaviParams } from '../../constants/NaviParams'
-import { SCREENS } from '../../constants/RoutePath'
 import { UserRequest } from '../../services/user'
 import useAuthStore from '../../store/authStore'
 import { COLORS } from '../../constants/variables'
+import AppText from '../../components/common/AppText'
 
 function WithdrawalScreen() {
   const navigation = useNavigation<NativeStackNavigationProp<NaviParams>>()
@@ -43,50 +43,69 @@ function WithdrawalScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <TouchableOpacity style={styles.backButton} onPress={() => navigation.navigate(SCREENS.MY_PAGE_SCREEN)}>
-        <Text style={styles.backButtonText}>뒤로가기</Text>
-      </TouchableOpacity>
-      <Text style={styles.title}>회원탈퇴</Text>
-      <View style={styles.checkboxContainer}>
-        <CheckBox value={isChecked} onValueChange={setIsChecked} tintColors={{ true: '#FF6347', false: '#666' }} />
-        <Text style={styles.checkboxLabel}>탈퇴 시, 복구가 불가능하며 {'\n'}데이터가 삭제되는 것에 동의합니다.</Text>
+      <AppText style={styles.title}>회원탈퇴</AppText>
+      <View style={styles.withdrawlContainer}>
+        <View style={styles.checkboxContainer}>
+          <CheckBox value={isChecked} onValueChange={setIsChecked} tintColors={{ true: '#FF6347', false: '#666' }} />
+          <AppText style={styles.checkboxLabel}>
+            탈퇴 시, 복구가 불가능하며 {'\n'}데이터가 삭제되는 것에 동의합니다.
+          </AppText>
+        </View>
+        <TouchableOpacity
+          style={[styles.button, !isChecked && styles.buttonDisabled]}
+          onPress={handleWithdrawal}
+          disabled={!isChecked}
+        >
+          <AppText style={styles.buttonText}>탈퇴하기</AppText>
+        </TouchableOpacity>
       </View>
-      <TouchableOpacity
-        style={[styles.button, !isChecked && styles.buttonDisabled]}
-        onPress={handleWithdrawal}
-        disabled={!isChecked}
-      >
-        <Text style={styles.buttonText}>탈퇴하기</Text>
-      </TouchableOpacity>
     </SafeAreaView>
   )
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, padding: 20, backgroundColor: COLORS.dark },
-  backButton: {
-    position: 'absolute',
-    top: 30,
-    left: 10,
-    backgroundColor: '#ccc',
-    padding: 5,
-    borderRadius: 5,
-    zIndex: 1,
+  container: {
+    flex: 1,
+    backgroundColor: COLORS.dark,
   },
-  backButtonText: { color: '#333', fontSize: 12 },
   title: {
     fontSize: 22,
-    fontWeight: 'bold',
+    fontWeight: 600,
     textAlign: 'center',
     marginBottom: 50,
-    marginTop: 10,
+    marginTop: 50,
     color: COLORS.white,
   },
-  checkboxContainer: { flexDirection: 'row', alignItems: 'center', marginBottom: 20 },
-  checkboxLabel: { marginLeft: 10, fontSize: 14, color: '#666' },
-  button: { backgroundColor: COLORS.dinosRed, padding: 15, borderRadius: 5, alignItems: 'center' },
-  buttonDisabled: { backgroundColor: '#ccc' },
-  buttonText: { color: '#fff', fontSize: 16, fontWeight: 'bold' },
+  withdrawlContainer: {
+    flex: 0.8,
+    justifyContent: 'center',
+    padding: 30,
+    gap: 60,
+  },
+  checkboxContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 10,
+  },
+  checkboxLabel: {
+    marginLeft: 10,
+    fontSize: 14,
+    color: '#666',
+  },
+  button: {
+    backgroundColor: COLORS.dinosRed,
+    padding: 15,
+    borderRadius: 5,
+    alignItems: 'center',
+  },
+  buttonDisabled: {
+    backgroundColor: '#ccc',
+  },
+  buttonText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: 600,
+  },
 })
 
 export default WithdrawalScreen

--- a/src/services/interceptor.ts
+++ b/src/services/interceptor.ts
@@ -82,14 +82,14 @@ api.interceptors.response.use(
           })
         } catch (refreshError) {
           console.log('Token refresh failed:', refreshError)
-          Alert.alert('토근 갱신에 실패했습니다. 다시 로그인해주세요')
+          Alert.alert('토큰 갱신에 실패했습니다. 다시 로그인해주세요')
           const { logout } = useAuthStore.getState()
           logout()
           return Promise.reject(refreshError)
         }
       } else if (errorData && errorData.error) {
         console.log('errorData.error :', errorData.error)
-        Alert.alert('토근이 만료 되었습니다. 다시 로그인해주세요')
+        Alert.alert('토큰이 만료 되었습니다. 다시 로그인해주세요')
         logout()
         return Promise.reject(error)
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4763,6 +4763,7 @@ __metadata:
     react-native-get-random-values: ^1.11.0
     react-native-google-places-autocomplete: ^2.5.7
     react-native-maps: ^1.20.1
+    react-native-permissions: ^5.2.3
     react-native-reanimated: ^3.16.1
     react-native-safe-area-context: ^4.14.0
     react-native-screens: ^4.0.0
@@ -9279,6 +9280,20 @@ __metadata:
     react-native-web:
       optional: true
   checksum: 3451f2cb98a0cfcac973d73d8a5bd8bc3673490ca1b3c85f6bd54110028201a7cbbcffbac56ccb931acb31e02bca8aac5805269bc13e94d93bfef868035074a7
+  languageName: node
+  linkType: hard
+
+"react-native-permissions@npm:^5.2.3":
+  version: 5.2.3
+  resolution: "react-native-permissions@npm:5.2.3"
+  peerDependencies:
+    react: ">=18.1.0"
+    react-native: ">=0.70.0"
+    react-native-windows: ">=0.70.0"
+  peerDependenciesMeta:
+    react-native-windows:
+      optional: true
+  checksum: 4048dfc18edcb8ef8b1cb5c208ea0d48a31d1ec8cc4002b2f97f3691018b73e614a69e75c2386ca4ad276942e21f6e99fa1d9d1ed7ec49f40eddf80d0af21a3a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

<!-- 연관된 이슈번호를 입력해주세요(ex: #9 컨테이너 환경 세팅) -->

- #42 

## 📝 작업 내용

- 로그인 스크린에 개인정보처리방침 링크 추가 (웹 링크로 연결)
- 맵 스크린 진입 시 위치 권한 확인 기능 추가
- 회원탈퇴 스크린 헤더에 뒤로가기 버튼 설정

## 📢 기타 확인사항
- 권한 확인기능은 hook으로 분리했습니다. 
- 권한이 필요한 각 기능별로 권한을 확인할지, 앱 설치 후 첫 실행 시 한번에 모든 권한을 확인할 지 논의가 필요합니다.
